### PR TITLE
Return transaction success or failure

### DIFF
--- a/lib/has_state_machine/state.rb
+++ b/lib/has_state_machine/state.rb
@@ -83,6 +83,8 @@ module HasStateMachine
           rollback_transition unless object.update("#{object.state_attribute}": state)
         end
       end
+
+      object.reload.public_send(object.state_attribute) == state
     end
 
     private


### PR DESCRIPTION

# Description

I would like to always be able to do something like `object.status.transition_to(:new_state)` and get back a success/failure boolean.

Since transactions return nil from the block, this changes that to return a boolean if the transition was successfull.

- Adds boolean return for transactional transitions


Fixes # (issue)

## Checklist

- [x] I added the appropriate label to this PR.
- [ ] I have made corresponding changes to the documentation if needed.
- [x] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1. Major (breaking change)
- [ ] 2. Minor (non-breaking, backwards compatible change)
- [x] 3. Patch (non-breaking, backwards compatible bug fix)
- [ ] 4. No immediate release is required
