### PR TITLE
misc: Remove attributes invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0']
+        ruby: ['3.0']
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.0']
+        ruby: ['2.7', '3.0', '3.3']
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -26,6 +26,11 @@ jobs:
 
       - name: Lint
         run: bundle exec rake lint
+
+      - name: Test against rails main
+        run: |
+          bundle exec appraisal rails-main bundle install
+          bundle exec appraisal rails-main rake test
 
       - name: Test against rails 7.0
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.3']
+        ruby: ['3.0']
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -26,11 +26,6 @@ jobs:
 
       - name: Lint
         run: bundle exec rake lint
-
-      - name: Test against rails main
-        run: |
-          bundle exec appraisal rails-main bundle install
-          bundle exec appraisal rails-main rake test
 
       - name: Test against rails 7.0
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,6 @@ jobs:
       - name: Lint
         run: bundle exec rake lint
 
-      - name: Test against rails main
-        run: |
-          bundle exec appraisal rails-main bundle install
-          bundle exec appraisal rails-main rake test
-
       - name: Test against rails 7.0
         run: |
           bundle exec appraisal rails-7-0 bundle install

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.7)
     minitest (5.17.0)
     net-imap (0.3.4)
       date
@@ -109,7 +110,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.14.2-arm64-darwin)
+    nokogiri (1.14.2)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.19.2)
     parser (2.7.1.4)
@@ -189,7 +191,7 @@ DEPENDENCIES
   has_state_machine!
   pry
   pry-rails
-  sqlite3
+  sqlite3 (~> 1.4)
   standard
 
 BUNDLED WITH

--- a/has_state_machine.gemspec
+++ b/has_state_machine.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 5.2"
 
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~> 1.4"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-rails"
   spec.add_development_dependency "standard"

--- a/lib/has_state_machine/definition.rb
+++ b/lib/has_state_machine/definition.rb
@@ -51,7 +51,7 @@ module HasStateMachine
         # Defines the namespace of the models possible states.
         # Can be overwritten to use a different namespace.
         define_singleton_method :workflow_namespace do
-          (options[:workflow_namespace] || "Workflow::#{self}")
+          options[:workflow_namespace] || "Workflow::#{self}"
         end
 
         ##

--- a/lib/has_state_machine/state.rb
+++ b/lib/has_state_machine/state.rb
@@ -33,7 +33,7 @@ module HasStateMachine
     def initialize(object)
       @object = object
 
-      super state
+      super(state)
     end
 
     ##

--- a/lib/has_state_machine/state_helpers.rb
+++ b/lib/has_state_machine/state_helpers.rb
@@ -78,7 +78,7 @@ module HasStateMachine
       # Getter for the current state of the model based on the configured state
       # attribute.
       def current_state
-        public_send(state_attribute)
+        self[state_attribute]
       end
 
       ##

--- a/lib/has_state_machine/state_helpers.rb
+++ b/lib/has_state_machine/state_helpers.rb
@@ -67,7 +67,7 @@ module HasStateMachine
         # @example Check if a post is published
         #   > post.published?
         #   #=> true
-        define_method "#{state}?" do
+        define_method :"#{state}?" do
           current_state == state
         end
       end

--- a/lib/has_state_machine/state_helpers.rb
+++ b/lib/has_state_machine/state_helpers.rb
@@ -78,7 +78,7 @@ module HasStateMachine
       # Getter for the current state of the model based on the configured state
       # attribute.
       def current_state
-        attributes.with_indifferent_access[state_attribute]
+        public_send(state_attribute)
       end
 
       ##


### PR DESCRIPTION
# Description

After doing some digging around performance - it looks like we're needlessly instantiating this attributes hash every time one of the predicate methods is called. There isn't really a need to do this and it seems expensive.

## Checklist

- [ ] I added the appropriate label to this PR.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1. Major (breaking change)
- [x] 2. Minor (non-breaking, backwards compatible change)
- [ ] 3. Patch (non-breaking, backwards compatible bug fix)
- [ ] 4. No immediate release is required
