### PR TITLE
fix: Gotcha with validation order

### DIFF
--- a/lib/has_state_machine/state.rb
+++ b/lib/has_state_machine/state.rb
@@ -21,11 +21,6 @@ module HasStateMachine
     delegate :possible_transitions, :transactional?, :state, to: "self.class"
 
     ##
-    # Add errors to the ActiveRecord object rather than the HasStateMachine::State
-    # class.
-    delegate :errors, to: :object
-
-    ##
     # Initializes the HasStateMachine::State instance.
     #
     # @example

--- a/lib/has_state_machine/state_helpers.rb
+++ b/lib/has_state_machine/state_helpers.rb
@@ -114,7 +114,12 @@ module HasStateMachine
       def state_instance_validations
         return unless state_class.present?
 
-        public_send(state_attribute.to_s).valid?
+        state_instance = public_send(state_attribute.to_s)
+        return if state_instance.valid?
+
+        state_instance.errors.each do |error|
+          errors.add(error.attribute, error.type)
+        end
       end
     end
 

--- a/test/has_state_machine/state_test.rb
+++ b/test/has_state_machine/state_test.rb
@@ -79,14 +79,6 @@ class HasStateMachine::StateTest < ActiveSupport::TestCase
     it { assert_equal %w[swimming floating tanning tubing lotioning], subject.possible_transitions }
   end
 
-  describe "#errors" do
-    it "delegates to the object" do
-      object.errors.add(:base, "foobar")
-
-      assert_equal({base: %w[foobar]}, subject.errors.messages)
-    end
-  end
-
   describe "#transition_to" do
     describe "callbacks" do
       it "runs before_transition callbacks" do


### PR DESCRIPTION
# Description

Currently there is a gotcha where if you have validations that run before the `has_state_machine` call in a class definition, it will end up clearing out any existing errors on the object b/c we delegate the `errors` method to the object of the state instance and `valid?` clears any existing errors. This PR fixes this issue by removing the delegation and manually adding the errors to the object.

## Checklist

- [x] I added the appropriate label to this PR.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have added tests that prove my change is effective.

## Merging

Please choose the type of release that is required for this change.

- [ ] 1. Major (breaking change)
- [ ] 2. Minor (non-breaking, backwards compatible change)
- [x] 3. Patch (non-breaking, backwards compatible bug fix)
- [ ] 4. No immediate release is required
